### PR TITLE
fix: retain empty version strings in `buildDAG`

### DIFF
--- a/src/build-dag.js
+++ b/src/build-dag.js
@@ -56,7 +56,7 @@ function createPackageNode({
     packageName,
     version: _package ? _package.version : workspaceMeta.version,
     ...dependencyType ? { dependencyType } : {},
-    ...dependencyRange ? { dependencyRange } : {},
+    ...typeof dependencyRange === 'string' ? { dependencyRange } : {},
     branch: [...dag.branch, dag.packageName].filter(Boolean),
     ..._package ? { isCycle: dag.branch.includes(packageName) } : {},
   };


### PR DESCRIPTION
#90