### PR TITLE
feat(#114): support wildcard versions

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -8,18 +8,20 @@ function trackNewVersion({
   newRange,
   newVersion,
 }) {
-  // wildcards don't need to be changed
-  if (oldRange === '*') {
-    return '*';
-  }
-
   let range = new semver.Range(newRange);
 
   if (range.set.length > 1) {
     console.warn(`Current range has an OR (${name} ${oldRange}) and is too hard to increment, falling back to ^`);
     newRange = `^${newVersion}`;
   } else if (range.set[0].length === 1) {
-    newRange = newVersion;
+    let raw = range.raw.trim();
+
+    // wildcards remain the same
+    if (raw === '*' || raw === '') {
+      newRange = raw;
+    } else {
+      newRange = newVersion;
+    }
   } else {
     let left = range.set[0][0].semver;
     let right = range.set[0][1].semver;

--- a/src/version.js
+++ b/src/version.js
@@ -8,7 +8,13 @@ function trackNewVersion({
   newRange,
   newVersion,
 }) {
+  // wildcards don't need to be changed
+  if (oldRange === '*') {
+    return '*';
+  }
+
   let range = new semver.Range(newRange);
+
   if (range.set.length > 1) {
     console.warn(`Current range has an OR (${name} ${oldRange}) and is too hard to increment, falling back to ^`);
     newRange = `^${newVersion}`;
@@ -17,6 +23,7 @@ function trackNewVersion({
   } else {
     let left = range.set[0][0].semver;
     let right = range.set[0][1].semver;
+
     if (left.major !== right.major) {
       newRange = `^${newVersion}`;
     } else {

--- a/src/version.js
+++ b/src/version.js
@@ -14,11 +14,11 @@ function trackNewVersion({
     console.warn(`Current range has an OR (${name} ${oldRange}) and is too hard to increment, falling back to ^`);
     newRange = `^${newVersion}`;
   } else if (range.set[0].length === 1) {
-    let raw = range.raw.trim();
-
     // wildcards remain the same
-    if (raw === '*' || raw === '') {
-      newRange = raw;
+    // NOTE: wildcard range is empty string
+    // SEE: https://github.com/npm/node-semver/blob/bcab95a966413b978dc1e7bdbcb8f495b63303cd/test/ranges/to-comparators.js#L10-L12
+    if (range.range === '') {
+      newRange = oldRange;
     } else {
       newRange = newVersion;
     }

--- a/test/version-test.js
+++ b/test/version-test.js
@@ -83,6 +83,16 @@ describe(function() {
       expect(newRange).to.equal('1.0.1');
     });
 
+    it('tracks invalid wildcards (by not doing anything)', function() {
+      let oldRange = ' * ';
+      let newRange = oldRange;
+      let newVersion = '1.0.1';
+
+      newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+
+      expect(newRange).to.equal('*');
+    });
+
     it('tracks wildcards (by not doing anything)', function() {
       let oldRange = '*';
       let newRange = oldRange;
@@ -91,6 +101,16 @@ describe(function() {
       newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
 
       expect(newRange).to.equal('*');
+    });
+
+    it('tracks invalid empty version (by not doing anything)', function() {
+      let oldRange = '';
+      let newRange = oldRange;
+      let newVersion = '1.0.1';
+
+      newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+
+      expect(newRange).to.equal('');
     });
 
     it('uses ~ on major version zero with ^', function() {

--- a/test/version-test.js
+++ b/test/version-test.js
@@ -83,14 +83,14 @@ describe(function() {
       expect(newRange).to.equal('1.0.1');
     });
 
-    it('tracks invalid wildcards (by not doing anything)', function() {
+    it('tracks wildcards with padding (by not doing anything)', function() {
       let oldRange = ' * ';
       let newRange = oldRange;
       let newVersion = '1.0.1';
 
       newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
 
-      expect(newRange).to.equal('*');
+      expect(newRange).to.equal(' * ');
     });
 
     it('tracks wildcards (by not doing anything)', function() {
@@ -103,7 +103,7 @@ describe(function() {
       expect(newRange).to.equal('*');
     });
 
-    it('tracks invalid empty version (by not doing anything)', function() {
+    it('tracks empty version (by not doing anything)', function() {
       let oldRange = '';
       let newRange = oldRange;
       let newVersion = '1.0.1';

--- a/test/version-test.js
+++ b/test/version-test.js
@@ -83,6 +83,16 @@ describe(function() {
       expect(newRange).to.equal('1.0.1');
     });
 
+    it('tracks wildcards (by not doing anything)', function() {
+      let oldRange = '*';
+      let newRange = oldRange;
+      let newVersion = '1.0.1';
+
+      newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+
+      expect(newRange).to.equal('*');
+    });
+
     it('uses ~ on major version zero with ^', function() {
       let oldRange = '^0.0.0';
       let newRange = oldRange;


### PR DESCRIPTION
Resolves #114, allowing wirdcard versions -- useful for denoting "always latest" dependencies in a monorepo