### PR TITLE
chore: remove `fixturify.readSync` deprecation notice

### DIFF
--- a/test/attach-test.js
+++ b/test/attach-test.js
@@ -113,7 +113,7 @@ describe(attach, function() {
 
     await attach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(workspace).to.deep.equal(defaultWorkspace);
   });
@@ -168,7 +168,7 @@ describe(attach, function() {
 
     await attach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(workspace).to.deep.equal(defaultWorkspace);
   });
@@ -223,7 +223,7 @@ describe(attach, function() {
 
     await attach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(workspace).to.deep.equal(defaultWorkspace);
   });

--- a/test/detach-test.js
+++ b/test/detach-test.js
@@ -92,7 +92,7 @@ describe(detach, function() {
 
     await detach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(prompt).to.be.calledOnce;
 
@@ -159,7 +159,7 @@ describe(detach, function() {
 
     await detach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(prompt).to.be.calledOnce;
 
@@ -214,7 +214,7 @@ describe(detach, function() {
 
     await detach({ cwd });
 
-    let workspace = fixturify.readSync(tmpPath, { exclude: ['.git'] });
+    let workspace = fixturify.readSync(tmpPath, { ignore: ['.git'] });
 
     expect(prompt).to.not.be.called;
 

--- a/test/release-test.js
+++ b/test/release-test.js
@@ -20,7 +20,7 @@ describe(_release, function() {
 
   function readWorkspaces() {
     return fixturify.readSync(tmpPath, {
-      exclude: [
+      ignore: [
         '.git',
         '**/CHANGELOG.md',
       ],


### PR DESCRIPTION
"fixturify.readSync no longer supports options.exclude, please use options.ignore instead."