### PR TITLE
feat: allow multiple extensions at once

### DIFF
--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -19,7 +19,7 @@ async function changedFiles({
   silent,
   fromCommit,
   packages = [],
-  ext,
+  exts = [],
 } = {}) {
   let workspaceCwd = await getWorkspaceCwd(cwd);
 
@@ -47,7 +47,7 @@ async function changedFiles({
     }
 
     for (let file of _changedFiles) {
-      if (ext && !file.endsWith(ext)) {
+      if (exts.length && exts.every(ext => !file.endsWith(ext))) {
         continue;
       }
 

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -149,7 +149,7 @@ describe(changedFiles, function() {
     let _changedFiles = await changedFiles({
       cwd: tmpPath,
       silent: true,
-      ext: 'txt',
+      exts: ['txt', 'none'],
     });
 
     expect(_changedFiles).to.deep.equal([


### PR DESCRIPTION
BREAKING CHANGE: `ext` string is now `exts` array of strings