### PR TITLE
fix: remove unused `sinceBranch` arg

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -96,7 +96,7 @@ async function buildChangeGraph({
     } else if (sinceBranch) {
       tagCommit = await getCommonAncestor('HEAD', sinceBranch, _package.cwd);
     } else {
-      tagCommit = await getCommitSinceLastRelease(_package, sinceBranch);
+      tagCommit = await getCommitSinceLastRelease(_package);
     }
 
     if (!cachedChangedFiles[_package.cwd]) {


### PR DESCRIPTION
Discovered here https://github.com/CrowdStrike/monorepo-next/pull/136/files#r498824657