### PR TITLE
feat: expose `getLatestReleaseCommit`

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -3,37 +3,14 @@
 const buildDAG = require('./build-dag');
 const execa = require('execa');
 const {
-  getCommitAtTag,
-  getFirstCommit,
   getLinesFromOutput,
   isCommitAncestorOf,
   getCommonAncestor,
+  getCommitSinceLastRelease,
 } = require('./git');
 
 function union(a, b) {
   return [...new Set([...a, ...b])];
-}
-
-async function getCommitSinceLastRelease(_package) {
-  let version = _package.version;
-
-  let matches = version.match(/(.*)-detached.*/);
-
-  if (matches) {
-    version = matches[1];
-  }
-
-  let tag = `${_package.packageName}@${version}`;
-
-  try {
-    return await getCommitAtTag(tag, _package.cwd);
-  } catch (err) {
-    if (err.stderr.includes(`fatal: ambiguous argument '${tag}': unknown revision or path not in the working tree.`)) {
-      return await getFirstCommit(_package.cwd);
-    } else {
-      throw err;
-    }
-  }
 }
 
 async function getPackageChangedFiles(tagCommit, currentCommit, _package) {

--- a/src/get-latest-release-commit.js
+++ b/src/get-latest-release-commit.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const {
+  getWorkspaceCwd,
+  getCommitSinceLastRelease,
+} = require('./git');
+const buildDepGraph = require('./build-dep-graph');
+
+async function getPackage({
+  cwd,
+  packageName,
+}) {
+  let workspaceCwd = await getWorkspaceCwd(cwd);
+
+  let workspaceMeta = await buildDepGraph(workspaceCwd);
+
+  let packages = [...Object.values(workspaceMeta.packages), workspaceMeta];
+
+  let _package = packages.find(_package => _package.packageName === packageName);
+
+  return _package;
+}
+
+async function getLatestReleaseCommit({
+  cwd,
+  packageName,
+}) {
+  let _package = await getPackage({
+    cwd,
+    packageName,
+  });
+
+  let commit = await getCommitSinceLastRelease(_package);
+
+  return commit;
+}
+
+module.exports = getLatestReleaseCommit;

--- a/src/index.js
+++ b/src/index.js
@@ -5,4 +5,5 @@ module.exports = {
   changedFiles: require('./changed-files'),
   release: require('./release'),
   getChangelog: require('./get-changelog'),
+  getLatestReleaseCommit: require('./get-latest-release-commit'),
 };

--- a/test/get-latest-release-commit-test.js
+++ b/test/get-latest-release-commit-test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { describe, it } = require('./helpers/mocha');
+const { expect } = require('./helpers/chai');
+const getLatestReleaseCommit = require('../src/get-latest-release-commit');
+const fixturify = require('fixturify');
+const stringifyJson = require('../src/json').stringify;
+const execa = require('execa');
+const { gitInit } = require('git-fixtures');
+const {
+  getCurrentCommit,
+} = require('./helpers/git');
+
+describe(getLatestReleaseCommit, function() {
+  let tmpPath;
+
+  beforeEach(async function() {
+    tmpPath = await gitInit();
+  });
+
+  it('works', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app': {
+          'package.json': stringifyJson({
+            'name': '@scope/my-app',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'chore: release'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/my-app@1.0.0'], { cwd: tmpPath });
+
+    let commit = await getCurrentCommit(tmpPath);
+
+    let latestReleaseCommit = await getLatestReleaseCommit({
+      cwd: tmpPath,
+      packageName: '@scope/my-app',
+    });
+
+    expect(latestReleaseCommit).to.equal(commit);
+  });
+
+  it('works without tag', async function() {
+    let commit = await getCurrentCommit(tmpPath);
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app': {
+          'package.json': stringifyJson({
+            'name': '@scope/my-app',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'chore: release'], { cwd: tmpPath });
+
+    let latestReleaseCommit = await getLatestReleaseCommit({
+      cwd: tmpPath,
+      packageName: '@scope/my-app',
+    });
+
+    expect(latestReleaseCommit).to.equal(commit);
+  });
+
+  it('works detached', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app': {
+          'package.json': stringifyJson({
+            'name': '@scope/my-app',
+            'version': '1.0.0-detached',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'chore: release'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/my-app@1.0.0'], { cwd: tmpPath });
+
+    let commit = await getCurrentCommit(tmpPath);
+
+    let latestReleaseCommit = await getLatestReleaseCommit({
+      cwd: tmpPath,
+      packageName: '@scope/my-app',
+    });
+
+    expect(latestReleaseCommit).to.equal(commit);
+  });
+});


### PR DESCRIPTION
For convenience to be used externally.