### PR TITLE
fix: never use `require` to load `package.json`

### DIFF
--- a/src/build-dep-graph.js
+++ b/src/build-dep-graph.js
@@ -6,6 +6,7 @@ const glob = promisify(require('glob'));
 const semver = require('semver');
 const dependencyTypes = require('./dependency-types');
 const execa = require('execa');
+const readJson = require('./json').read;
 
 function copyDeps(left, right) {
   for (let dependencyType of dependencyTypes) {
@@ -13,7 +14,7 @@ function copyDeps(left, right) {
   }
 }
 
-function firstPass(workspaceMeta, workspacePackageJson, packageDirs) {
+async function firstPass(workspaceMeta, workspacePackageJson, packageDirs) {
   workspaceMeta.packageName = workspacePackageJson.name || 'Workspace Root';
   workspaceMeta.version = workspacePackageJson.version;
   workspaceMeta.isPrivate = true;
@@ -22,7 +23,7 @@ function firstPass(workspaceMeta, workspacePackageJson, packageDirs) {
   for (let packageDir of packageDirs) {
     let packageJson;
     try {
-      packageJson = require(path.join(packageDir, 'package'));
+      packageJson = await readJson(path.join(packageDir, 'package.json'));
     } catch (err) {
       // ignore empty folders
       continue;
@@ -75,7 +76,7 @@ function secondPass(workspaceMeta) {
 }
 
 async function buildDepGraph(workspaceCwd) {
-  let workspacePackageJson = require(path.join(workspaceCwd, 'package'));
+  let workspacePackageJson = await readJson(path.join(workspaceCwd, 'package.json'));
 
   let { workspaces } = workspacePackageJson;
 
@@ -104,7 +105,7 @@ async function buildDepGraph(workspaceCwd) {
     cwd: workspaceCwd,
   };
 
-  firstPass(workspaceMeta, workspacePackageJson, packageDirs);
+  await firstPass(workspaceMeta, workspacePackageJson, packageDirs);
   secondPass(workspaceMeta);
 
   return workspaceMeta;

--- a/src/get-changelog.js
+++ b/src/get-changelog.js
@@ -8,6 +8,7 @@ const semver = require('semver');
 const {
   getWorkspaceCwd,
 } = require('./git');
+const readJson = require('./json').read;
 
 const defaults = require('standard-version/defaults');
 
@@ -21,7 +22,7 @@ async function getChangelog({
   fromCommit,
   cached,
 }) {
-  let { name, version } = require(path.join(cwd, 'package'));
+  let { name, version } = await readJson(path.join(cwd, 'package.json'));
 
   let tagPrefix = `${name}@`;
 


### PR DESCRIPTION
Since require caches and the versions could change, we could be reading the wrong values.