### PR TITLE
fix: pin semver package

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "execa": "^5.0.0",
     "glob": "^7.1.4",
     "inquirer": "^7.0.0",
-    "semver": "^6.3.0",
+    "semver": "6.3.0",
     "standard-version": "9.0.0",
     "yargs": "^16.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3869,7 +3869,7 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.1.0, semver@^6.3.0:
+semver@6.3.0, semver@^6.0.0, semver@^6.1.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Either they break semver multiple times in 7.x range, or we are using non-public API that keeps changing.