### PR TITLE
fix: ignores old child package changes in root package

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "execa": "^5.0.0",
     "glob": "^7.1.4",
     "inquirer": "^7.0.0",
+    "minimatch": "^3.0.4",
     "semver": "7.3.4",
     "standard-version": "9.1.1",
     "yargs": "^16.0.0"

--- a/src/build-dep-graph.js
+++ b/src/build-dep-graph.js
@@ -87,9 +87,9 @@ async function buildDepGraph({
       .split(/\r?\n/)
       .map(workspace => path.relative(workspaceCwd, workspace));
   } else {
-    let packages = workspaces.packages || workspaces;
+    let packagesGlobs = workspaces.packages || workspaces;
 
-    let _2dFilesArray = await Promise.all(packages.map(packagesGlob => {
+    let _2dFilesArray = await Promise.all(packagesGlobs.map(packagesGlob => {
       return glob(packagesGlob, {
         cwd: workspaceCwd,
       });

--- a/src/build-dep-graph.js
+++ b/src/build-dep-graph.js
@@ -81,13 +81,17 @@ async function buildDepGraph({
 
   let { workspaces } = workspacePackageJson;
 
+  let packagesGlobs;
+
   let _1dFilesArray;
   if (!workspaces) {
     _1dFilesArray = (await execa.command('pnpm recursive exec -- node -e "console.log(process.cwd())"', { cwd: workspaceCwd })).stdout
       .split(/\r?\n/)
       .map(workspace => path.relative(workspaceCwd, workspace));
+
+    packagesGlobs = [];
   } else {
-    let packagesGlobs = workspaces.packages || workspaces;
+    packagesGlobs = workspaces.packages || workspaces;
 
     let _2dFilesArray = await Promise.all(packagesGlobs.map(packagesGlob => {
       return glob(packagesGlob, {
@@ -104,6 +108,7 @@ async function buildDepGraph({
 
   let workspaceMeta = {
     cwd: workspaceCwd,
+    packagesGlobs,
   };
 
   await firstPass(workspaceMeta, workspacePackageJson, packageDirs);

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -734,4 +734,50 @@ describe(buildChangeGraph, function() {
       }).length;
     }));
   });
+
+  it('ignores old child package changes in root package', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-a',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'name': 'root',
+        'version': '1.0.0',
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'fix: foo'], { cwd: tmpPath });
+    await execa('git', ['tag', 'root@1.0.0'], { cwd: tmpPath });
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'index.js': 'console.log()',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'feat: foo'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+
+    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
+
+    expect(packagesWithChanges).to.match(this.match(packagesWithChanges => {
+      return !packagesWithChanges.some(pkg => {
+        return pkg.dag.packageName === 'root';
+      });
+    }));
+  });
 });

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -688,4 +688,50 @@ describe(buildChangeGraph, function() {
       },
     ]));
   });
+
+  it('ignores child package changes in root package', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-a',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'name': 'root',
+        'version': '1.0.0',
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'fix: foo'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+    await execa('git', ['tag', 'root@1.0.0'], { cwd: tmpPath });
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'index.js': 'console.log()',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'feat: foo'], { cwd: tmpPath });
+
+    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
+
+    expect(packagesWithChanges).to.match(this.match(packagesWithChanges => {
+      return !packagesWithChanges.filter(pkg => {
+        return pkg.dag.packageName === 'root';
+      }).length;
+    }));
+  });
 });

--- a/test/build-dep-graph-test.js
+++ b/test/build-dep-graph-test.js
@@ -29,6 +29,9 @@ describe(buildDepGraph, function() {
       packageName: 'Workspace Root',
       version: undefined,
       isPrivate: true,
+      packagesGlobs: [
+        'packages/*',
+      ],
       dependencies: {},
       devDependencies: {
         '@scope/package-a': '^1.0.0',
@@ -114,6 +117,9 @@ describe(buildDepGraph, function() {
       packageName: 'Workspace Root',
       version: undefined,
       isPrivate: true,
+      packagesGlobs: [
+        'packages/*',
+      ],
       dependencies: {},
       devDependencies: {},
       optionalDependencies: {},


### PR DESCRIPTION
The child package exclusion from monorepo root logic only considered the current release. Old package changes would still show up for the monorepo root on future releases because the root tag stayed in pre-release location.