### PR TITLE
fix: remove logging of js `changed` and `changedFiles`

### DIFF
--- a/bin/commands/changed-files.js
+++ b/bin/commands/changed-files.js
@@ -17,10 +17,14 @@ module.exports = {
   async handler(argv) {
     const changedFiles = require('../../src/changed-files');
 
-    await changedFiles({
+    let _changedFiles = await changedFiles({
       ...argv,
       shouldOnlyIncludeReleasable: argv['only-include-releasable'],
       shouldExcludeDevChanges: argv['exclude-dev-changes'],
     });
+
+    for (let file of _changedFiles) {
+      console.log(file);
+    }
   },
 };

--- a/bin/commands/changed.js
+++ b/bin/commands/changed.js
@@ -13,10 +13,14 @@ module.exports = {
   async handler(argv) {
     const changed = require('../../src/changed');
 
-    await changed({
+    let _changed = await changed({
       ...argv,
       shouldOnlyIncludeReleasable: argv['only-include-releasable'],
       shouldExcludeDevChanges: argv['exclude-dev-changes'],
     });
+
+    for (let name of _changed) {
+      console.log(name);
+    }
   },
 };

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -18,7 +18,6 @@ async function arePathsTheSame(path1, path2) {
 
 async function changedFiles({
   cwd = process.cwd(),
-  silent,
   shouldOnlyIncludeReleasable = builder['only-include-releasable'].default,
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
   fromCommit,
@@ -61,9 +60,6 @@ async function changedFiles({
         continue;
       }
 
-      if (!silent) {
-        console.log(file);
-      }
       changedFiles.push(file);
     }
   }

--- a/src/changed.js
+++ b/src/changed.js
@@ -18,7 +18,6 @@ async function arePathsTheSame(path1, path2) {
 
 async function changed({
   cwd = process.cwd(),
-  silent,
   shouldOnlyIncludeReleasable = builder['only-include-releasable'].default,
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
   fromCommit,
@@ -43,9 +42,6 @@ async function changed({
   for (let { dag } of packagesWithChanges) {
     let name = await arePathsTheSame(dag.cwd, workspaceCwd) ? dag.packageName : path.basename(dag.cwd);
 
-    if (!silent) {
-      console.log(name);
-    }
     _changed.push(name);
   }
 


### PR DESCRIPTION
These are too noisy. Let's move the logging to the command.

BREAKING CHANGE: the `silent` option is removed from the js functions, and the js functions no longer log to console.