### PR TITLE
feat: new utility function for getting a list of changed files grouped

### DIFF
--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -25,6 +25,7 @@ async function changedFiles({
   cached,
   packages = [],
   exts = [],
+  globs = [],
 } = {}) {
   let workspaceCwd = await getWorkspaceCwd(cwd);
 
@@ -57,11 +58,14 @@ async function changedFiles({
     }
 
     for (let file of _changedFiles) {
-      if (exts.length && exts.every(ext => !file.endsWith(`.${ext}`))) {
+      if (exts.length && exts.some(ext => file.endsWith(`.${ext}`))) {
+        changedFiles.push(file);
         continue;
       }
 
-      changedFiles.push(file);
+      if (globs.length && globs.some(glob => glob.test(file))) {
+        changedFiles.push(file);
+      }
     }
   }
 

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -7,6 +7,7 @@ const fs = { ...require('fs'), ...require('fs').promises };
 const {
   getWorkspaceCwd,
 } = require('./git');
+const minimatch = require('minimatch');
 
 const { builder } = require('../bin/commands/changed-files');
 
@@ -64,7 +65,7 @@ async function changedFiles({
         isMatch = true;
       } else if (exts.some(ext => file.endsWith(`.${ext}`))) {
         isMatch = true;
-      } else if (globs.some(glob => glob.test(file))) {
+      } else if (globs.some(glob => minimatch(file, glob))) {
         isMatch = true;
       }
 

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -57,18 +57,19 @@ async function changedFiles({
       continue;
     }
 
-    if (exts.length === 0 && globs.length === 0) {
-      changedFiles.push(... _changedFiles);
-    } else {
-      for (let file of _changedFiles) {
-        if (exts.length && exts.some(ext => file.endsWith(`.${ext}`))) {
-          changedFiles.push(file);
-          continue;
-        }
+    for (let file of _changedFiles) {
+      let isMatch = false;
 
-        if (globs.length && globs.some(glob => glob.test(file))) {
-          changedFiles.push(file);
-        }
+      if (!exts.length && !globs.length) {
+        isMatch = true;
+      } else if (exts.some(ext => file.endsWith(`.${ext}`))) {
+        isMatch = true;
+      } else if (globs.some(glob => glob.test(file))) {
+        isMatch = true;
+      }
+
+      if (isMatch) {
+        changedFiles.push(file);
       }
     }
   }

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -57,14 +57,18 @@ async function changedFiles({
       continue;
     }
 
-    for (let file of _changedFiles) {
-      if (exts.length && exts.some(ext => file.endsWith(`.${ext}`))) {
-        changedFiles.push(file);
-        continue;
-      }
+    if (exts.length === 0 && globs.length === 0) {
+      changedFiles.push(... _changedFiles);
+    } else {
+      for (let file of _changedFiles) {
+        if (exts.length && exts.some(ext => file.endsWith(`.${ext}`))) {
+          changedFiles.push(file);
+          continue;
+        }
 
-      if (globs.length && globs.some(glob => glob.test(file))) {
-        changedFiles.push(file);
+        if (globs.length && globs.some(glob => glob.test(file))) {
+          changedFiles.push(file);
+        }
       }
     }
   }

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -175,12 +175,111 @@ describe(changedFiles, function() {
     let _changedFiles = await changedFiles({
       cwd: tmpPath,
       silent: true,
-      globs: [/\.my-config\.json$/],
+      globs: ['**/.my-config.json'],
     });
 
     expect(_changedFiles).to.deep.equal([
       'packages/package-a/.my-config.json',
       '.my-config.json',
+    ]);
+  });
+
+  it('globs top level vs nested', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          '.my-config.json': 'test',
+        },
+      },
+      '.my-config.json': 'test',
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: ['.my-config.json'],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      '.my-config.json',
+    ]);
+  });
+
+  it('multiple globs', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          '.config-foo.json': 'test',
+        },
+      },
+      '.config-bar.yaml': 'test',
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: ['**/.config-foo.json', '**/.config-bar.yaml'],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/.config-foo.json',
+      '.config-bar.yaml',
+    ]);
+  });
+
+  it('globs brace expansion', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          '.config.json': 'test',
+          '.config.yaml': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: ['**/.config.+(json|yaml)'],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/.config.json',
+      'packages/package-a/.config.yaml',
+    ]);
+  });
+
+  it('globs star matches', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          '.config.json': 'test',
+          '.config.yaml': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: ['**/.config.*'],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/.config.json',
+      'packages/package-a/.config.yaml',
     ]);
   });
 
@@ -204,7 +303,7 @@ describe(changedFiles, function() {
     let _changedFiles = await changedFiles({
       cwd: tmpPath,
       silent: true,
-      globs: [/\.my-config\.json$/],
+      globs: ['**/.my-config.json'],
       exts: ['txt'],
     });
 

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -156,6 +156,66 @@ describe(changedFiles, function() {
     ]);
   });
 
+  it('filters globs only', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'changed.txt': 'test',
+          '.my-config.json': 'test',
+        },
+        'changed-without-config-1.txt': 'test',
+      },
+      'changed-without-config-2.txt': 'test',
+      '.my-config.json': 'test',
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: [/\.my-config\.json$/],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/.my-config.json',
+      '.my-config.json',
+    ]);
+  });
+
+  it('filters globs and exts', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'changed.txt': 'test',
+          '.my-config.json': 'test',
+        },
+        'changed-without-config-1.txt': 'test',
+        'non-matching-file-1.json': 'test',
+      },
+      'changed-without-config-2.txt': 'test',
+      'non-matching-file-2.json': 'test',
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      globs: [/\.my-config\.json$/],
+      exts: ['txt'],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/.my-config.json',
+      'packages/package-a/changed.txt',
+      'changed-without-config-2.txt',
+      'packages/changed-without-config-1.txt',
+    ]);
+  });
+
   it('accepts an arbitrary commit to calculate difference', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -184,30 +184,6 @@ describe(changedFiles, function() {
     ]);
   });
 
-  it('globs top level vs nested', async function() {
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          '.my-config.json': 'test',
-        },
-      },
-      '.my-config.json': 'test',
-    });
-
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-
-    let _changedFiles = await changedFiles({
-      cwd: tmpPath,
-      silent: true,
-      globs: ['.my-config.json'],
-    });
-
-    expect(_changedFiles).to.deep.equal([
-      '.my-config.json',
-    ]);
-  });
-
   it('multiple globs', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {
@@ -230,56 +206,6 @@ describe(changedFiles, function() {
     expect(_changedFiles).to.deep.equal([
       'packages/package-a/.config-foo.json',
       '.config-bar.yaml',
-    ]);
-  });
-
-  it('globs brace expansion', async function() {
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          '.config.json': 'test',
-          '.config.yaml': 'test',
-        },
-      },
-    });
-
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-
-    let _changedFiles = await changedFiles({
-      cwd: tmpPath,
-      silent: true,
-      globs: ['**/.config.+(json|yaml)'],
-    });
-
-    expect(_changedFiles).to.deep.equal([
-      'packages/package-a/.config.json',
-      'packages/package-a/.config.yaml',
-    ]);
-  });
-
-  it('globs star matches', async function() {
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          '.config.json': 'test',
-          '.config.yaml': 'test',
-        },
-      },
-    });
-
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-
-    let _changedFiles = await changedFiles({
-      cwd: tmpPath,
-      silent: true,
-      globs: ['**/.config.*'],
-    });
-
-    expect(_changedFiles).to.deep.equal([
-      'packages/package-a/.config.json',
-      'packages/package-a/.config.yaml',
     ]);
   });
 


### PR DESCRIPTION
- Utility function to check for generic changes files
- Might be useful for checking on changes per file type
- Similar API to `changedFiles` but needs `matchers` object to assign matched files to respective group:

```js
matchers: {
  'files': /.txt/,
  'configs': /.my-config.json/,
},
```

produces (assuming given files have been changed):

```js
{
  files: ['foo.txt', 'package-a/bar.txt'],
  configs: ['.my-config.json', 'package-b/.my-config.json']
}
```

-----

Also I think it should be possible to replace `changedFiles` implementation with something like:

```js
let matchers = exts.map(
  (ext) => {
    return { 
      ext: new RegExp('\.' + ext)
    }
  }
);

return changedStuff({
  matchers,
  ...arguments
}).values().flat();
```

Obviously a little bit overkill.