### PR TITLE
fix: strip dirs from git status

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -35,7 +35,7 @@ async function getPackageChangedFiles({
 
   let committedChanges = await git(['diff', '--name-only', `${olderCommit}...${newerCommit}`, packageCwd], options);
   committedChanges = getLinesFromOutput(committedChanges);
-  let dirtyChanges = await git(['status', '--porcelain', packageCwd], options);
+  let dirtyChanges = await git(['status', '--porcelain', packageCwd, '-u'], options);
   dirtyChanges = getLinesFromOutput(dirtyChanges).map(line => line.substr(3));
   let changedFiles = Array.from(union(committedChanges, dirtyChanges));
 

--- a/src/releasable.js
+++ b/src/releasable.js
@@ -132,6 +132,12 @@ async function getChangedReleasableFiles({
 }) {
   changedFiles = new Set(changedFiles);
 
+  for (let changedFile of changedFiles) {
+    if (changedFile.endsWith(path.sep)) {
+      throw new Error(`expected '${changedFile}' to be a file, but it is a directory`);
+    }
+  }
+
   let changedPublishedFiles = await _getChangedReleasableFiles({
     cwd: packageCwd,
     changedFiles: map(changedFiles, file => path.relative(packageCwd, path.join(workspacesCwd, file))),

--- a/test/releasable-test.js
+++ b/test/releasable-test.js
@@ -194,6 +194,16 @@ describe(function() {
       ]);
     });
 
+    it('throws when changed files includes a dir', async function() {
+      let promise = getChangedReleasableFiles({
+        changedFiles: [
+          'package-a/dir1/',
+        ],
+      });
+
+      await expect(promise).to.eventually.be.rejectedWith(`expected 'package-a/dir1/' to be a file, but it is a directory`);
+    });
+
     describe('shouldExcludeDevChanges', function() {
       let shouldExcludeDevChanges = true;
 


### PR DESCRIPTION
This causes problems when trying to create temp files when trying to calculate releasability.