### PR TITLE
feat!: fix changed, matching all apps with same basename

### DIFF
--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -79,6 +79,3 @@ async function changedFiles({
 }
 
 module.exports = changedFiles;
-Object.assign(module.exports, {
-  arePathsTheSame,
-});

--- a/src/changed.js
+++ b/src/changed.js
@@ -2,11 +2,9 @@
 
 const buildDepGraph = require('./build-dep-graph');
 const buildChangeGraph = require('./build-change-graph');
-const path = require('path');
 const {
   getWorkspaceCwd,
 } = require('./git');
-const { arePathsTheSame } = require('./changed-files');
 
 const { builder } = require('../bin/commands/changed');
 
@@ -33,13 +31,7 @@ async function changed({
     cached,
   });
 
-  let _changed = [];
-
-  for (let { dag } of packagesWithChanges) {
-    let name = await arePathsTheSame(dag.cwd, workspaceCwd) ? dag.packageName : path.basename(dag.cwd);
-
-    _changed.push(name);
-  }
+  let _changed = packagesWithChanges.map(({ dag }) => dag.packageName);
 
   return _changed;
 }

--- a/test/changed-test.js
+++ b/test/changed-test.js
@@ -112,9 +112,9 @@ describe(changed, function() {
     });
 
     expect(_changed).to.deep.equal([
-      'package-a',
+      '@scope/package-a',
       'my-app-1',
-      'package-b',
+      '@scope/package-b',
       'root',
     ]);
   });
@@ -196,9 +196,9 @@ describe(changed, function() {
 
     expect(_changed).to.deep.equal([
       'my-app-2',
-      'package-a',
+      '@scope/package-a',
       'my-app-1',
-      'package-b',
+      '@scope/package-b',
       'root',
     ]);
   });
@@ -227,10 +227,10 @@ describe(changed, function() {
     });
 
     expect(cachedChanged).to.deep.equal([
-      'package-a',
+      '@scope/package-a',
       'root',
       'my-app-1',
-      'package-b',
+      '@scope/package-b',
     ]);
 
     let commit = await getCurrentCommit(tmpPath);
@@ -253,10 +253,10 @@ describe(changed, function() {
     });
 
     expect(_changed).to.deep.equal([
-      'package-a',
+      '@scope/package-a',
       'root',
       'my-app-1',
-      'package-b',
+      '@scope/package-b',
     ]);
 
     _changed = await changed({
@@ -277,10 +277,10 @@ describe(changed, function() {
 
     expect(_changed).to.deep.equal([
       'my-app-2',
-      'package-a',
+      '@scope/package-a',
       'root',
       'my-app-1',
-      'package-b',
+      '@scope/package-b',
     ]);
   });
 });


### PR DESCRIPTION
## What?
I have made changes to return package names instead of base names for all the apps changed.

## Why?
When there are multiple apps with same basenames(in different paths), change detection matches all those apps even though only one is changed

## Impact

This change only affects changed and nothing else.