### PR TITLE
feat: expose toCommit in `changed` and `changedFiles`

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -66,11 +66,11 @@ async function buildChangeGraph({
   shouldExcludeDevChanges,
   fromCommit,
   fromCommitIfNewer,
+  toCommit = 'HEAD',
   sinceBranch,
   cached,
 }) {
   let packagesWithChanges = {};
-  let toCommit = 'HEAD';
   let sinceBranchCommit;
 
   for (let _package of collectPackages(workspaceMeta)) {

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -22,6 +22,7 @@ async function changedFiles({
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
   fromCommit,
   fromCommitIfNewer,
+  toCommit,
   sinceBranch,
   cached,
   packages = [],
@@ -38,6 +39,7 @@ async function changedFiles({
     shouldExcludeDevChanges,
     fromCommit,
     fromCommitIfNewer,
+    toCommit,
     sinceBranch,
     cached,
   });

--- a/src/changed.js
+++ b/src/changed.js
@@ -14,6 +14,7 @@ async function changed({
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
   fromCommit,
   fromCommitIfNewer,
+  toCommit,
   sinceBranch,
   cached,
 } = {}) {
@@ -27,6 +28,7 @@ async function changed({
     shouldExcludeDevChanges,
     fromCommit,
     fromCommitIfNewer,
+    toCommit,
     sinceBranch,
     cached,
   });

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -241,7 +241,7 @@ describe(changedFiles, function() {
     ]);
   });
 
-  it('accepts an arbitrary commit to calculate difference', async function() {
+  it('accepts an arbitrary from commit to calculate difference', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -274,6 +274,42 @@ describe(changedFiles, function() {
 
     expect(_changedFiles).to.deep.equal([
       'packages/my-app-1/changed.txt',
+    ]);
+  });
+
+  it('accepts an arbitrary to commit to calculate difference', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'changed.txt': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let commit = await getCurrentCommit(tmpPath);
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app-1': {
+          'changed.txt': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      toCommit: commit,
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'packages/package-a/changed.txt',
     ]);
   });
 

--- a/test/changed-test.js
+++ b/test/changed-test.js
@@ -119,7 +119,7 @@ describe(changed, function() {
     ]);
   });
 
-  it('accepts an arbitrary commit to calculate difference', async function() {
+  it('accepts an arbitrary from commit to calculate difference', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {
         'my-app-1': {
@@ -152,6 +152,42 @@ describe(changed, function() {
 
     expect(_changed).to.deep.equal([
       'my-app-2',
+    ]);
+  });
+
+  it('accepts an arbitrary to commit to calculate difference', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app-1': {
+          'changed.txt': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let commit = await getCurrentCommit(tmpPath);
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'my-app-2': {
+          'changed.txt': 'test',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let _changed = await changed({
+      cwd: tmpPath,
+      silent: true,
+      toCommit: commit,
+    });
+
+    expect(_changed).to.deep.equal([
+      'my-app-1',
     ]);
   });
 


### PR DESCRIPTION
We want to be able to calculate any commit without having to checkout the commit first.