### PR TITLE
feat: short-circuit buildDAG

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -41,19 +41,19 @@ async function getPackageChangedFiles({
 }
 
 function crawlDag(dag, packagesWithChanges) {
-  for (let node of dag.dependents) {
-    if (packagesWithChanges[node.packageName]) {
+  for (let group of dag.node.dependents) {
+    if (packagesWithChanges[group.node.packageName]) {
       continue;
     }
 
-    packagesWithChanges[node.packageName] = {
+    packagesWithChanges[group.node.packageName] = {
       changedFiles: [],
       changedReleasableFiles: [],
-      dag: node,
+      dag: group,
     };
 
-    if (node.dependencyType !== 'devDependencies') {
-      crawlDag(node, packagesWithChanges);
+    if (group.dependencyType !== 'devDependencies') {
+      crawlDag(group, packagesWithChanges);
     }
   }
 }

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -52,11 +52,11 @@ async function changedFiles({
     changedFiles: _changedFiles,
     dag,
   } of packagesWithChanges) {
-    if (packages.length && !packages.includes(path.basename(dag.cwd))) {
+    if (packages.length && !packages.includes(path.basename(dag.node.cwd))) {
       continue;
     }
 
-    if (isPackageCwd && !await arePathsTheSame(dag.cwd, cwd)) {
+    if (isPackageCwd && !await arePathsTheSame(dag.node.cwd, cwd)) {
       continue;
     }
 

--- a/src/changed.js
+++ b/src/changed.js
@@ -33,7 +33,7 @@ async function changed({
     cached,
   });
 
-  let _changed = packagesWithChanges.map(({ dag }) => dag.packageName);
+  let _changed = packagesWithChanges.map(({ dag }) => dag.node.packageName);
 
   return _changed;
 }

--- a/src/detach.js
+++ b/src/detach.js
@@ -53,12 +53,12 @@ async function detach({
     // don't mutate package.json until after DAG is built
     myPackageJson.version = `${major}.${minor}.${patch}-detached`;
 
-    if (dag.dependents.length) {
+    if (dag.node.dependents.length) {
       // include space as to never match a similarly named package
       let workspaceKey = 'Workspace Root';
 
-      let choices = dag.dependents.map(dependent => {
-        return dependent.packageName || path.basename(dependent.cwd);
+      let choices = dag.node.dependents.map(dependent => {
+        return dependent.node.packageName || path.basename(dependent.node.cwd);
       });
 
       let { answers } = await inquirer.prompt([{
@@ -72,18 +72,18 @@ async function detach({
         // switch to key/value instead of array?
         let isPackage = answer !== workspaceKey;
 
-        return dag.dependents.find(dependent => {
-          return isPackage ? dependent.packageName === answer : !dependent.isPackage;
+        return dag.node.dependents.find(dependent => {
+          return isPackage ? dependent.node.packageName === answer : !dependent.node.isPackage;
         });
       });
 
       // prevent loops
       const attach = require('./attach');
 
-      for (let node of dependents) {
+      for (let group of dependents) {
         await attach({
           package: path.basename(cwd),
-          cwd: node.cwd,
+          cwd: group.node.cwd,
         });
       }
     }

--- a/src/get-changelog.js
+++ b/src/get-changelog.js
@@ -40,7 +40,7 @@ async function getChangelog({
   });
 
   packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-    return dag.packageName && dag.version;
+    return dag.node.packageName && dag.node.version;
   });
 
   let releaseTrees = await buildReleaseGraph({

--- a/src/release.js
+++ b/src/release.js
@@ -53,7 +53,7 @@ async function release({
   });
 
   packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-    return dag.packageName && dag.version;
+    return dag.node.packageName && dag.node.version;
   });
 
   if (!packagesWithChanges.some(({ changedReleasableFiles }) => changedReleasableFiles.length)) {

--- a/src/run.js
+++ b/src/run.js
@@ -30,7 +30,7 @@ async function run({
   let stderr = '';
 
   for (let { dag } of packagesWithChanges) {
-    let cp = execa('yarn', args, { cwd: dag.cwd });
+    let cp = execa('yarn', args, { cwd: dag.node.cwd });
 
     if (!silent) {
       cp.stdout.pipe(process.stdout);

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -70,7 +70,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/index.js',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -148,7 +150,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/index.js',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -198,7 +202,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/dir2/test.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -239,7 +245,9 @@ describe(buildChangeGraph, function() {
           'index.js',
         ],
         dag: this.match({
-          packageName: 'workspace-root',
+          node: {
+            packageName: 'workspace-root',
+          },
         }),
       },
     ]));
@@ -312,7 +320,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/package.json',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -367,7 +377,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/index.js',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -422,7 +434,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/package.json',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -478,7 +492,9 @@ describe(buildChangeGraph, function() {
             'packages/package-a/index.js',
           ],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));
@@ -586,7 +602,9 @@ describe(buildChangeGraph, function() {
             'packages/package-a/index.js',
           ],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));
@@ -640,7 +658,9 @@ describe(buildChangeGraph, function() {
             'packages/package-a/index.js',
           ],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));
@@ -700,7 +720,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/index.js',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -753,7 +775,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/package.json',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -772,7 +796,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/index.js',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -835,7 +861,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/changed.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -867,7 +895,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/changed.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -887,7 +917,9 @@ describe(buildChangeGraph, function() {
           'packages/my-app-1/changed.txt',
         ],
         dag: this.match({
-          packageName: 'my-app-1',
+          node: {
+            packageName: 'my-app-1',
+          },
         }),
       },
     ]));
@@ -905,7 +937,9 @@ describe(buildChangeGraph, function() {
           'packages/my-app-1/changed.txt',
         ],
         dag: this.match({
-          packageName: 'my-app-1',
+          node: {
+            packageName: 'my-app-1',
+          },
         }),
       },
       {
@@ -916,7 +950,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/changed.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -980,7 +1016,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/changed.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -1013,7 +1051,9 @@ describe(buildChangeGraph, function() {
           'packages/my-app-1/changed.txt',
         ],
         dag: this.match({
-          packageName: 'my-app-1',
+          node: {
+            packageName: 'my-app-1',
+          },
         }),
       },
     ]));
@@ -1033,7 +1073,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/changed.txt',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -1054,7 +1096,9 @@ describe(buildChangeGraph, function() {
           'packages/my-app-1/package.json',
         ],
         dag: this.match({
-          packageName: 'my-app-1',
+          node: {
+            packageName: 'my-app-1',
+          },
         }),
       },
       {
@@ -1067,7 +1111,9 @@ describe(buildChangeGraph, function() {
           'packages/package-a/package.json',
         ],
         dag: this.match({
-          packageName: '@scope/package-a',
+          node: {
+            packageName: '@scope/package-a',
+          },
         }),
       },
     ]));
@@ -1266,7 +1312,9 @@ describe(buildChangeGraph, function() {
           ],
           changedReleasableFiles: [],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));
@@ -1325,7 +1373,9 @@ describe(buildChangeGraph, function() {
             'packages/package-a/index.js',
           ],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));
@@ -1376,7 +1426,9 @@ describe(buildChangeGraph, function() {
           ],
           changedReleasableFiles: [],
           dag: this.match({
-            packageName: '@scope/package-a',
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
       ]));

--- a/test/build-dag-test.js
+++ b/test/build-dag-test.js
@@ -28,80 +28,92 @@ describe(buildDAG, function() {
     let dag = buildDAG(await buildDepGraph({ workspaceCwd: cwd }), _package);
 
     expect(dag).to.match(this.match({
-      isPackage: true,
-      cwd: matchPath('/workspace/packages/package-a'),
-      packageName: '@scope/package-a',
-      version: '1.0.0',
-      branch: [],
-      isCycle: false,
-      dependents: [
-        {
-          isPackage: true,
-          cwd: matchPath('/workspace/packages/package-b'),
-          packageName: '@scope/package-b',
-          version: '2.0.0',
-          dependencyType: 'dependencies',
-          dependencyRange: '^1.0.0',
-          branch: [
-            '@scope/package-a',
-          ],
-          isCycle: false,
-          dependents: [
-            {
-              isPackage: true,
-              cwd: matchPath('/workspace/packages/package-a'),
-              packageName: '@scope/package-a',
-              version: '1.0.0',
-              dependencyType: 'devDependencies',
-              dependencyRange: '^2.0.0',
-              branch: [
-                '@scope/package-a',
-                '@scope/package-b',
-              ],
-              isCycle: true,
+      parent: undefined,
+      node: {
+        isPackage: true,
+        cwd: matchPath('/workspace/packages/package-a'),
+        packageName: '@scope/package-a',
+        version: '1.0.0',
+        dependents: [
+          this.match({
+            parent: {
+              node: {
+                packageName: '@scope/package-a',
+              },
             },
-            {
+            dependencyType: 'dependencies',
+            dependencyRange: '^1.0.0',
+            node: {
+              isPackage: true,
+              cwd: matchPath('/workspace/packages/package-b'),
+              packageName: '@scope/package-b',
+              version: '2.0.0',
+              dependents: [
+                this.match({
+                  parent: {
+                    node: {
+                      packageName: '@scope/package-b',
+                    },
+                  },
+                  dependencyType: 'devDependencies',
+                  dependencyRange: '^2.0.0',
+                  node: {
+                    isPackage: true,
+                    cwd: matchPath('/workspace/packages/package-a'),
+                    packageName: '@scope/package-a',
+                    version: '1.0.0',
+                  },
+                }),
+                this.match({
+                  parent: {
+                    node: {
+                      packageName: '@scope/package-b',
+                    },
+                  },
+                  dependencyType: 'dependencies',
+                  dependencyRange: '^2.0.0',
+                  node: {
+                    isPackage: true,
+                    cwd: matchPath('/workspace/packages/package-c'),
+                    packageName: '@scope/package-c',
+                    version: '3.0.0',
+                  },
+                }),
+              ],
+            },
+          }),
+          this.match({
+            parent: {
+              node: {
+                packageName: '@scope/package-a',
+              },
+            },
+            dependencyType: 'optionalDependencies',
+            dependencyRange: '^1.0.0',
+            node: {
               isPackage: true,
               cwd: matchPath('/workspace/packages/package-c'),
               packageName: '@scope/package-c',
               version: '3.0.0',
-              dependencyType: 'dependencies',
-              dependencyRange: '^2.0.0',
-              branch: [
-                '@scope/package-a',
-                '@scope/package-b',
-              ],
-              isCycle: false,
-              dependents: [],
             },
-          ],
-        },
-        {
-          isPackage: true,
-          cwd: matchPath('/workspace/packages/package-c'),
-          packageName: '@scope/package-c',
-          version: '3.0.0',
-          dependencyType: 'optionalDependencies',
-          dependencyRange: '^1.0.0',
-          branch: [
-            '@scope/package-a',
-          ],
-          isCycle: false,
-          dependents: [],
-        },
-        {
-          isPackage: false,
-          cwd: matchPath('/workspace'),
-          packageName: 'Workspace Root',
-          version: undefined,
-          dependencyType: 'devDependencies',
-          dependencyRange: '^1.0.0',
-          branch: [
-            '@scope/package-a',
-          ],
-          dependents: [],
-        },
-      ],
+          }),
+          this.match({
+            parent: {
+              node: {
+                packageName: '@scope/package-a',
+              },
+            },
+            dependencyType: 'devDependencies',
+            dependencyRange: '^1.0.0',
+            node: {
+              isPackage: false,
+              cwd: matchPath('/workspace'),
+              packageName: 'Workspace Root',
+              version: undefined,
+            },
+          }),
+        ],
+      },
     }));
   });
 
@@ -111,81 +123,92 @@ describe(buildDAG, function() {
     let dag = buildDAG(await buildDepGraph({ workspaceCwd: cwd }), _package);
 
     expect(dag).to.match(this.match({
-      isPackage: true,
-      cwd: matchPath('/workspace/packages/package-b'),
-      packageName: '@scope/package-b',
-      version: '2.0.0',
-      branch: [],
-      isCycle: false,
-      dependents: [
-        {
-          isPackage: true,
-          cwd: matchPath('/workspace/packages/package-a'),
-          packageName: '@scope/package-a',
-          version: '1.0.0',
-          dependencyType: 'devDependencies',
-          dependencyRange: '^2.0.0',
-          branch: [
-            '@scope/package-b',
-          ],
-          isCycle: false,
-          dependents: [
-            {
-              isPackage: true,
-              cwd: matchPath('/workspace/packages/package-b'),
-              packageName: '@scope/package-b',
-              version: '2.0.0',
-              dependencyType: 'dependencies',
-              dependencyRange: '^1.0.0',
-              branch: [
-                '@scope/package-b',
-                '@scope/package-a',
-              ],
-              isCycle: true,
+      parent: undefined,
+      node: {
+        isPackage: true,
+        cwd: matchPath('/workspace/packages/package-b'),
+        packageName: '@scope/package-b',
+        version: '2.0.0',
+        dependents: [
+          this.match({
+            parent: {
+              node: {
+                packageName: '@scope/package-b',
+              },
             },
-            {
+            dependencyType: 'devDependencies',
+            dependencyRange: '^2.0.0',
+            node: {
+              isPackage: true,
+              cwd: matchPath('/workspace/packages/package-a'),
+              packageName: '@scope/package-a',
+              version: '1.0.0',
+              dependents: [
+                this.match({
+                  parent: {
+                    node: {
+                      packageName: '@scope/package-a',
+                    },
+                  },
+                  dependencyType: 'dependencies',
+                  dependencyRange: '^1.0.0',
+                  node: {
+                    isPackage: true,
+                    cwd: matchPath('/workspace/packages/package-b'),
+                    packageName: '@scope/package-b',
+                    version: '2.0.0',
+                  },
+                }),
+                this.match({
+                  parent: {
+                    node: {
+                      packageName: '@scope/package-a',
+                    },
+                  },
+                  dependencyType: 'optionalDependencies',
+                  dependencyRange: '^1.0.0',
+                  node: {
+                    isPackage: true,
+                    cwd: matchPath('/workspace/packages/package-c'),
+                    packageName: '@scope/package-c',
+                    version: '3.0.0',
+                  },
+                }),
+                this.match({
+                  parent: {
+                    node: {
+                      packageName: '@scope/package-a',
+                    },
+                  },
+                  dependencyType: 'devDependencies',
+                  dependencyRange: '^1.0.0',
+                  node: {
+                    isPackage: false,
+                    cwd: matchPath('/workspace'),
+                    packageName: 'Workspace Root',
+                    version: undefined,
+                  },
+                }),
+              ],
+            },
+          }),
+          this.match({
+            parent: {
+              node: {
+                packageName: '@scope/package-b',
+              },
+            },
+            dependencyType: 'dependencies',
+            dependencyRange: '^2.0.0',
+            node: {
               isPackage: true,
               cwd: matchPath('/workspace/packages/package-c'),
               packageName: '@scope/package-c',
               version: '3.0.0',
-              dependencyType: 'optionalDependencies',
-              dependencyRange: '^1.0.0',
-              branch: [
-                '@scope/package-b',
-                '@scope/package-a',
-              ],
-              isCycle: false,
-              dependents: [],
             },
-            {
-              isPackage: false,
-              cwd: matchPath('/workspace'),
-              packageName: 'Workspace Root',
-              version: undefined,
-              dependencyType: 'devDependencies',
-              dependencyRange: '^1.0.0',
-              branch: [
-                '@scope/package-b',
-                '@scope/package-a',
-              ],
-              dependents: [],
-            },
-          ],
-        },
-        {
-          isPackage: true,
-          cwd: matchPath('/workspace/packages/package-c'),
-          packageName: '@scope/package-c',
-          version: '3.0.0',
-          dependencyType: 'dependencies',
-          dependencyRange: '^2.0.0',
-          branch: [
-            '@scope/package-b',
-          ],
-          isCycle: false,
-          dependents: [],
-        },
-      ],
+          }),
+        ],
+      },
     }));
   });
 
@@ -195,13 +218,14 @@ describe(buildDAG, function() {
     let dag = buildDAG(await buildDepGraph({ workspaceCwd: cwd }), _package);
 
     expect(dag).to.match(this.match({
-      isPackage: true,
-      cwd: matchPath('/workspace/packages/package-c'),
-      packageName: '@scope/package-c',
-      version: '3.0.0',
-      branch: [],
-      isCycle: false,
-      dependents: [],
+      parent: undefined,
+      node: {
+        isPackage: true,
+        cwd: matchPath('/workspace/packages/package-c'),
+        packageName: '@scope/package-c',
+        version: '3.0.0',
+        dependents: [],
+      },
     }));
   });
 
@@ -230,27 +254,31 @@ describe(buildDAG, function() {
 
     let dag = buildDAG(await buildDepGraph({ workspaceCwd: tmpPath }), packageName);
 
-    expect(dag).to.deep.equal({
-      isPackage: true,
-      cwd: path.join(tmpPath, 'packages/package-a'),
-      packageName,
-      version: '1.0.0',
-      branch: [],
-      isCycle: false,
-      dependents: [
-        {
-          isPackage: false,
-          cwd: tmpPath,
-          packageName: 'Workspace Root',
-          version: undefined,
-          dependencyType: 'devDependencies',
-          dependencyRange: '',
-          branch: [
-            packageName,
-          ],
-          dependents: [],
-        },
-      ],
-    });
+    expect(dag).to.match(this.match({
+      parent: undefined,
+      node: {
+        isPackage: true,
+        cwd: path.join(tmpPath, 'packages/package-a'),
+        packageName,
+        version: '1.0.0',
+        dependents: [
+          this.match({
+            parent: {
+              node: {
+                packageName,
+              },
+            },
+            dependencyType: 'devDependencies',
+            dependencyRange: '',
+            node: {
+              isPackage: false,
+              cwd: tmpPath,
+              packageName: 'Workspace Root',
+              version: undefined,
+            },
+          }),
+        ],
+      },
+    }));
   });
 });

--- a/test/build-release-graph-test.js
+++ b/test/build-release-graph-test.js
@@ -69,7 +69,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -157,7 +157,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = false;
@@ -230,7 +230,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = false;
@@ -318,7 +318,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -406,7 +406,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = false;
@@ -479,7 +479,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = false;
@@ -568,7 +568,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -656,7 +656,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -729,7 +729,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = false;
@@ -828,7 +828,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -946,7 +946,7 @@ describe(buildReleaseGraph, function() {
       let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
       packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-        return dag.packageName && dag.version;
+        return dag.node.packageName && dag.node.version;
       });
 
       let releaseTrees = await buildReleaseGraph({
@@ -1043,7 +1043,7 @@ describe(buildReleaseGraph, function() {
       let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
       packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-        return dag.packageName && dag.version;
+        return dag.node.packageName && dag.node.version;
       });
 
       let releaseTrees = await buildReleaseGraph({
@@ -1140,7 +1140,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let shouldBumpInRangeDependencies = true;
@@ -1207,7 +1207,7 @@ describe(buildReleaseGraph, function() {
     let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
 
     packagesWithChanges = packagesWithChanges.filter(({ dag }) => {
-      return dag.packageName && dag.version;
+      return dag.node.packageName && dag.node.version;
     });
 
     let getReleaseType = this.spy(buildReleaseGraph, 'getReleaseType');


### PR DESCRIPTION
Using a lookup table for visited packages can speed this up a lot.