### PR TITLE
feat: early exit some crawlDag calls

### DIFF
--- a/src/build-release-graph.js
+++ b/src/build-release-graph.js
@@ -122,6 +122,8 @@ async function secondPass({
   shouldInheritGreaterReleaseType,
   shouldExcludeDevChanges,
 }) {
+  let visitedNodes = new Set();
+
   for (let { dag, changedReleasableFiles } of packagesWithChanges) {
     if (!changedReleasableFiles.length) {
       continue;
@@ -131,6 +133,12 @@ async function secondPass({
       dag,
       parent,
     }) {
+      if (visitedNodes.has(dag.node.packageName)) {
+        return;
+      }
+
+      visitedNodes.add(dag.node.packageName);
+
       let doesPackageHaveChanges = !!releaseTrees[dag.node.packageName];
       if (!doesPackageHaveChanges) {
         let isDevDep = dag.dependencyType === 'devDependencies';


### PR DESCRIPTION
These don't re-enter like the other crawlDag calls, so it's safe to cache. This should be temporary. A more permanent solution like combining all the passes may be better.