### PR TITLE
Support pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-node": "^11.0.0",
     "fixturify": "^2.1.0",
     "git-fixtures": "^4.0.0",
+    "js-yaml": "^4.1.0",
     "mocha": "^10.0.0",
     "mocha-helpers": "^6.2.1",
     "remark-cli": "^10.0.0",


### PR DESCRIPTION
**Summary**
With pnpm, workspaces are no longer maintained in root package.json file. All the workspaces are defined in pnpm-workspace.yaml file
https://pnpm.io/pnpm-workspace_yaml
```
packages:
  # all packages in direct subdirs of packages/
  - 'packages/*'
  # all packages in subdirs of components/
  - 'components/**'
  # exclude packages that are inside test directories
  - '!**/test/**'
```
