### PR TITLE
refactor yarn spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "conventional-recommended-bump": "6.1.0",
     "debug": "^4.3.1",
     "execa": "^5.0.0",
-    "glob": "^8.0.0",
     "inquirer": "^8.0.0",
     "minimatch": "^5.0.0",
     "npm-packlist": "^5.0.0",

--- a/test/attach-test.js
+++ b/test/attach-test.js
@@ -43,6 +43,7 @@ const defaultWorkspace = {
     },
   },
   'package.json': stringifyJson({
+    'private': true,
     'workspaces': [
       'packages/*',
     ],
@@ -98,6 +99,7 @@ describe(attach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -153,6 +155,7 @@ describe(attach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -208,6 +211,7 @@ describe(attach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -36,6 +36,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -89,6 +90,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -119,6 +121,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -172,6 +175,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -214,6 +218,7 @@ describe(buildChangeGraph, function() {
     fixturify.writeSync(tmpPath, {
       'package.json': stringifyJson({
         'name': 'workspace-root',
+        'private': true,
         'version': '1.0.0',
         'workspaces': [
           'packages/*',
@@ -257,6 +262,7 @@ describe(buildChangeGraph, function() {
     fixturify.writeSync(tmpPath, {
       'package.json': stringifyJson({
         'name': 'workspace-root',
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -285,6 +291,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -339,6 +346,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -396,6 +404,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -454,6 +463,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -513,6 +523,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -544,6 +555,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -621,6 +633,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -678,6 +691,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -739,6 +753,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -823,6 +838,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -977,6 +993,7 @@ describe(buildChangeGraph, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -1131,6 +1148,7 @@ describe(buildChangeGraph, function() {
       },
       'package.json': stringifyJson({
         'name': 'root',
+        'private': true,
         'version': '1.0.0',
         'workspaces': [
           'packages/*',
@@ -1177,6 +1195,7 @@ describe(buildChangeGraph, function() {
       },
       'package.json': stringifyJson({
         'name': 'root',
+        'private': true,
         'version': '1.0.0',
         'workspaces': [
           'packages/*',
@@ -1223,6 +1242,7 @@ describe(buildChangeGraph, function() {
       },
       'package.json': stringifyJson({
         'name': 'root',
+        'private': true,
         'version': '1.0.0',
         'workspaces': [
           'packages/*',
@@ -1279,6 +1299,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -1339,6 +1360,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -1395,6 +1417,7 @@ describe(buildChangeGraph, function() {
           },
         },
         'package.json': stringifyJson({
+          'private': true,
           'workspaces': [
             'packages/*',
           ],
@@ -1438,6 +1461,7 @@ describe(buildChangeGraph, function() {
   it('respects config shouldBumpVersion', async function() {
     fixturify.writeSync(tmpPath, {
       'package.json': stringifyJson({
+        'private': true,
         'version': '0.0.0',
         'workspaces': [
           'packages/*',

--- a/test/detach-test.js
+++ b/test/detach-test.js
@@ -44,6 +44,7 @@ const defaultWorkspace = {
     },
   },
   'package.json': stringifyJson({
+    'private': true,
     'workspaces': [
       'packages/*',
     ],
@@ -126,6 +127,7 @@ describe(detach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -193,6 +195,7 @@ describe(detach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],
@@ -248,6 +251,7 @@ describe(detach, function() {
         },
       },
       'package.json': stringifyJson({
+        'private': true,
         'workspaces': [
           'packages/*',
         ],

--- a/test/fixtures/workspace/package.json
+++ b/test/fixtures/workspace/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "workspaces": [
     "packages/*"
   ],

--- a/test/release-test.js
+++ b/test/release-test.js
@@ -75,8 +75,9 @@ describe(_release, function() {
         },
         'my-app': {
           'package.json': stringifyJson({
-            'private': true,
             'name': 'my-app',
+            'private': true,
+            'version': '1.0.0',
             'devDependencies': {
               '@scope/package-a': '^1.0.0 || 1.0.0-detached',
               '@scope/package-b': '^2.0.0',
@@ -151,8 +152,9 @@ describe(_release, function() {
         },
         'my-app': {
           'package.json': stringifyJson({
-            'private': true,
             'name': 'my-app',
+            'private': true,
+            'version': '1.0.1',
             'devDependencies': {
               '@scope/package-a': '^2.0.0',
               '@scope/package-b': '^2.0.0',
@@ -176,7 +178,7 @@ describe(_release, function() {
 
     let lastCommitMessage = await getLastCommitMessage(tmpPath);
 
-    expect(lastCommitMessage).to.equal('chore(release): @scope/package-a@2.0.0,@scope/package-b@3.0.0,@scope/package-c@3.0.1');
+    expect(lastCommitMessage).to.equal('chore(release): my-app@1.0.1,@scope/package-a@2.0.0,@scope/package-b@3.0.0,@scope/package-c@3.0.1');
 
     let tags = await getTagsOnLastCommit(tmpPath);
 
@@ -184,6 +186,7 @@ describe(_release, function() {
       '@scope/package-a@2.0.0',
       '@scope/package-b@3.0.0',
       '@scope/package-c@3.0.1',
+      'my-app@1.0.1',
     ]);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,17 +1783,6 @@ glob@7.2.0, glob@^7.0.0, glob@^7.1.3, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.0:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.3.tgz#415c6eb2deed9e502c68fa44a272e6da6eeca42e"
-  integrity sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 global-dirs@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"


### PR DESCRIPTION
Summary

Instead of glob use `yarn workspaces list` to return workspaces. This is more accurate than globs

Test Plan
All tests are passing but some are timing out with default timeout

Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.