### PR TITLE
fix: support packages with same basename

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,5 +4,6 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 };

--- a/src/changed-files.js
+++ b/src/changed-files.js
@@ -52,7 +52,7 @@ async function changedFiles({
     changedFiles: _changedFiles,
     dag,
   } of packagesWithChanges) {
-    if (packages.length && !packages.includes(path.basename(dag.node.cwd))) {
+    if (packages.length && !packages.includes(path.relative(workspaceCwd, dag.node.cwd))) {
       continue;
     }
 

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -18,6 +18,10 @@ describe(changedFiles, function() {
   beforeEach(async function() {
     tmpPath = await gitInit();
 
+    await setUpFixtures();
+  });
+
+  async function setUpFixtures() {
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -56,7 +60,7 @@ describe(changedFiles, function() {
     await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
     await execa('git', ['tag', 'my-app-1@0.0.0'], { cwd: tmpPath });
     await execa('git', ['tag', 'root@0.0.0'], { cwd: tmpPath });
-  });
+  }
 
   it('works at root with no package', async function() {
     fixturify.writeSync(tmpPath, {

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -508,4 +508,44 @@ describe(changedFiles, function() {
       'changed',
     ]);
   });
+
+  it('can match a different package with same basename', async function() {
+    fixturify.writeSync(tmpPath, {
+      'package-a': {
+        'my-package': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-a',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package-b': {
+        'my-package': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-b',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'package-a/my-package',
+          'package-b/my-package',
+        ],
+      }),
+    });
+
+    let _changedFiles = await changedFiles({
+      cwd: tmpPath,
+      silent: true,
+      packages: [
+        'package-b/my-package',
+      ],
+    });
+
+    expect(_changedFiles).to.deep.equal([
+      'package-b/my-package/package.json',
+    ]);
+  });
 });

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -105,7 +105,7 @@ describe(changedFiles, function() {
       cwd: tmpPath,
       silent: true,
       packages: [
-        'package-a',
+        'packages/package-a',
       ],
     });
 
@@ -429,7 +429,7 @@ describe(changedFiles, function() {
       silent: true,
       cached: true,
       packages: [
-        'package-a',
+        'packages/package-a',
       ],
       exts: ['txt'],
     });
@@ -478,7 +478,7 @@ describe(changedFiles, function() {
       silent: true,
       cached: true,
       packages: [
-        'package-a',
+        'packages/package-a',
       ],
     });
 

--- a/test/changed-files-test.js
+++ b/test/changed-files-test.js
@@ -17,8 +17,6 @@ describe(changedFiles, function() {
 
   beforeEach(async function() {
     tmpPath = await gitInit();
-
-    await setUpFixtures();
   });
 
   async function setUpFixtures() {
@@ -63,6 +61,8 @@ describe(changedFiles, function() {
   }
 
   it('works at root with no package', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -87,6 +87,8 @@ describe(changedFiles, function() {
   });
 
   it('works at root with package', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -113,6 +115,8 @@ describe(changedFiles, function() {
   });
 
   it('works when run from package', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -136,6 +140,8 @@ describe(changedFiles, function() {
   });
 
   it('filters extensions', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -161,6 +167,8 @@ describe(changedFiles, function() {
   });
 
   it('filters globs only', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -191,6 +199,8 @@ describe(changedFiles, function() {
   });
 
   it('multiple globs', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -216,6 +226,8 @@ describe(changedFiles, function() {
   });
 
   it('matches dot files with globs', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       '.foo': '',
     });
@@ -235,6 +247,8 @@ describe(changedFiles, function() {
   });
 
   it('filters globs and exts', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -269,6 +283,8 @@ describe(changedFiles, function() {
   });
 
   it('accepts an arbitrary from commit to calculate difference', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -305,6 +321,8 @@ describe(changedFiles, function() {
   });
 
   it('accepts an arbitrary to commit to calculate difference', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -341,6 +359,8 @@ describe(changedFiles, function() {
   });
 
   it('can calulate difference since branch point', async function() {
+    await setUpFixtures();
+
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -386,6 +406,8 @@ describe(changedFiles, function() {
   });
 
   it('can cache the results', async function() {
+    await setUpFixtures();
+
     this.timeout(5e3);
 
     let _changedFiles;


### PR DESCRIPTION
If you structure your packages like "*/package", you will have lots of packages with the same basename, so we can't use this to scope changes to a package.

BREAKING CHANGE: This fix means everyone using `changedFiles.packages` needs to update to a full relative path instead of just the basename. For example, a package at "packages/my-package" will go from:

```js
changedFiles({
  packages: ['my-package'],
})
```

to

```js
changedFiles({
  packages: ['packages/my-package'],
})
```