### PR TITLE
accommodate removed package jsons

### DIFF
--- a/src/releasable.js
+++ b/src/releasable.js
@@ -73,7 +73,17 @@ async function prepareTmpPackage({
 
     await fs.mkdir(path.dirname(filePath), { recursive: true });
 
-    await fs.writeFile(filePath, '');
+    let text;
+
+    if (path.basename(filePath) === 'package.json') {
+      // removed packages will still match the root package.json's workspaces
+      // and packlist will throw if they aren't readable.
+      text = JSON.stringify({});
+    } else {
+      text = '';
+    }
+
+    await fs.writeFile(filePath, text);
   }
 }
 

--- a/test/releasable-test.js
+++ b/test/releasable-test.js
@@ -235,6 +235,29 @@ describe(function() {
       ]);
     });
 
+    it('handles a removed package', async function() {
+      fixturify.writeSync(this.tmpPath, {
+        'package.json': stringifyJson({
+          'private': true,
+          'workspaces': [
+            'packages/*',
+          ],
+        }),
+      });
+
+      let changedReleasableFiles = await getChangedReleasableFiles({
+        changedFiles: [
+          'packages/package-a/package.json',
+        ],
+        packageCwd: this.tmpPath,
+        workspacesCwd: this.tmpPath,
+      });
+
+      expect(changedReleasableFiles).to.deep.equal([
+        'packages/package-a/package.json',
+      ]);
+    });
+
     describe('shouldExcludeDevChanges', function() {
       let shouldExcludeDevChanges = true;
 


### PR DESCRIPTION
If you remove a whole package, the package's removed files show up as belonging to the monorepo root package. The package's package.json gets read in our temporary dir by packlist because the root package.json still matches the package. This prevents a malformed JSON error.