### PR TITLE
fix: speed up `removeSubDirs`

### DIFF
--- a/src/releasable.js
+++ b/src/releasable.js
@@ -29,9 +29,7 @@ function removeSubDirs(files) {
         return false;
       }
 
-      let relative = path.relative(file, nextFile);
-
-      let isSubDir = !relativePathRegex.test(relative);
+      let isSubDir = nextFile.startsWith(file);
 
       return isSubDir;
     });


### PR DESCRIPTION
If you have a massive amount of removed files, I think it was the `path.relative` that was slow. Doing it this way is both simpler and faster.