### PR TITLE
feat: Add support for CJS config file extension 

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,23 +1,14 @@
 'use strict';
 
+const glob = require('glob');
 const path = require('path');
 
 function loadPackageConfig(cwd) {
-  let nextConfig;
-
-  try {
-    nextConfig = require(path.join(cwd, 'monorepo-next.config.js'));
-  } catch (err) {
-    if (err.code !== 'MODULE_NOT_FOUND') {
-      throw err;
-    }
-
-    nextConfig = {};
-  }
+  const [configFile] = glob.sync('monorepo-next.config.{cjs,js}', { cwd });
 
   return {
     shouldBumpVersion: true,
-    ...nextConfig,
+    ...(configFile ? require(path.join(cwd, configFile)) : {}),
   };
 }
 

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -1482,6 +1482,28 @@ describe(buildChangeGraph, function() {
     expect(packagesWithChanges).to.be.empty;
   });
 
+  it('respects config shouldBumpVersion in CJS file', async function () {
+    fixturify.writeSync(tmpPath, {
+      'package.json': stringifyJson({
+        private: true,
+        version: '0.0.0',
+        workspaces: ['packages/*'],
+      }),
+      'monorepo-next.config.cjs': `module.exports = ${stringifyJson({
+        shouldBumpVersion: false,
+      })}`,
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
+
+    expect(packagesWithChanges).to.be.empty;
+  });
+
   it('handles changes across branches', async function() {
     let otherBranchName = 'test-branch';
 


### PR DESCRIPTION
Add support for CJS config file extension.

This will allow to use `monorepo-next.config.cjs` file, and will take precedence over `.js` (which can be implicitly ESM)