### PR TITLE
fix: always sort Object.keys to be deterministic

### DIFF
--- a/src/cycle.js
+++ b/src/cycle.js
@@ -96,7 +96,10 @@ function _getCycles({
       continue;
     }
 
-    for (let [packageName, dependencyRange] of Object.entries(_package[dependencyType])) {
+    let dependencies = _package[dependencyType];
+
+    for (let packageName of Object.keys(dependencies).sort()) {
+      let dependencyRange = dependencies[packageName];
       let _package = packages[packageName];
 
       _getCycles({
@@ -121,7 +124,9 @@ function getCycles(workspaceMeta, {
   let visitedNodes = {};
   let { packages } = workspaceMeta;
 
-  for (let _package of Object.values(packages)) {
+  for (let packageName of Object.keys(packages).sort()) {
+    let _package = packages[packageName];
+
     _getCycles({
       packages,
       _package,
@@ -132,7 +137,7 @@ function getCycles(workspaceMeta, {
     });
   }
 
-  return Object.keys(cycles);
+  return Object.keys(cycles).sort();
 }
 
 Object.assign(module.exports, {

--- a/test/cycle-test.js
+++ b/test/cycle-test.js
@@ -77,6 +77,60 @@ describe(function() {
           'packageA < dependencies < packageB < devDependencies < packageA',
         ]);
       });
+
+      it('is deterministic when packages not alphabetized', async function() {
+        let workspaceMeta = normalize({
+          packageB: {
+            version: '0.0.0',
+            dependencies: {
+              packageA: '0.0.0',
+            },
+          },
+          packageA: {
+            version: '0.0.0',
+            dependencies: {
+              packageB: '0.0.0',
+            },
+          },
+        });
+
+        let cycles = await getCycles(workspaceMeta);
+
+        expect(cycles).to.deep.equal([
+          'packageA < dependencies < packageB < dependencies < packageA',
+        ]);
+      });
+
+      it('is deterministic when dependencies not alphabetized', async function() {
+        let workspaceMeta = normalize({
+          packageA: {
+            version: '0.0.0',
+            dependencies: {
+              packageC: '0.0.0',
+              packageB: '0.0.0',
+            },
+          },
+          packageB: {
+            version: '0.0.0',
+            dependencies: {
+              packageA: '0.0.0',
+            },
+          },
+          packageC: {
+            version: '0.0.0',
+            dependencies: {
+              packageA: '0.0.0',
+            },
+          },
+        });
+
+        let cycles = await getCycles(workspaceMeta);
+
+        expect(cycles).to.deep.equal([
+          'packageA < dependencies < packageB < dependencies < packageA',
+          'packageA < dependencies < packageC < dependencies < packageA',
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
If packages are not alphabetized, or are rearranged in a monorepo, they can result in a different order of cycles, based on which node is chosen to start the loop. This forced sorting should solve that.