### PR TITLE
chore: fix tests to run with default branch

### DIFF
--- a/test/changed-test.js
+++ b/test/changed-test.js
@@ -15,7 +15,9 @@ describe(changed, function() {
   let tmpPath;
 
   beforeEach(async function() {
-    tmpPath = await gitInit();
+    tmpPath = await gitInit({
+      defaultBranchName: 'master',
+    });
 
     fixturify.writeSync(tmpPath, {
       'packages': {


### PR DESCRIPTION
If you have 'main' set locally as default, these tests fail.