### PR TITLE
feat: run ls-tree instead of diff if new package

### DIFF
--- a/src/get-latest-release-commit.js
+++ b/src/get-latest-release-commit.js
@@ -31,7 +31,7 @@ async function getLatestReleaseCommit({
     packageName,
   });
 
-  let commit = await getCommitSinceLastRelease(_package, { cwd: _package.cwd });
+  let commit = (await getCommitSinceLastRelease(_package, { cwd: _package.cwd })).sha;
 
   return commit;
 }

--- a/src/git.js
+++ b/src/git.js
@@ -89,10 +89,16 @@ async function getCommitSinceLastRelease(_package, options) {
   let tag = `${_package.packageName}@${version}`;
 
   try {
-    return await getCommitAtTag(tag, options);
+    return {
+      sha: await getCommitAtTag(tag, options),
+      isUnreleased: false,
+    };
   } catch (err) {
     if (err.stderr.includes(`fatal: ambiguous argument '${tag}': unknown revision or path not in the working tree.`)) {
-      return await getFirstCommit(options);
+      return {
+        sha: await getFirstCommit(options),
+        isUnreleased: true,
+      };
     } else {
       throw err;
     }


### PR DESCRIPTION
If a package is new (you can't find its last version tag), there is no point doing a diff against the beginning of time. `ls-tree` should get you the same results in less time.