### PR TITLE
fix: fix changelog truncating repository url

### DIFF
--- a/src/get-changelog.js
+++ b/src/get-changelog.js
@@ -103,7 +103,7 @@ async function _getChangelog({
       preset: require('standard-version/lib/preset-loader')(defaults),
       tagPrefix,
       releaseCount,
-      pkg: { path: cwd },
+      pkg: { path: path.join(cwd, 'package.json') },
       path: cwd,
     },
     context,


### PR DESCRIPTION
changelog is truncating repository url `///compare/@scope/my-app@1.0.0...@scope/my-app@1.0.1`. We didn't catch this issue when `conventional-changelog` updated to `5.1.0` because none of the tests are configured with repository block in package.json.