### PR TITLE
feat: add shouldValidateDependencyVisibility option

### DIFF
--- a/bin/commands/release.js
+++ b/bin/commands/release.js
@@ -37,6 +37,11 @@ module.exports = {
       default: false,
     },
     'exclude-dev-changes': commonArgs['exclude-dev-changes'],
+    'validate-dependency-visibility': {
+      describe: 'Prevent releasing public packages that depend on private packages.',
+      type: 'boolean',
+      default: false,
+    },
     'clean-up-after-failed-push': {
       describe: 'If there\'s already a new commit on the remote, clean up the commit and tags that won\'t be used',
       type: 'boolean',

--- a/src/build-release-graph.js
+++ b/src/build-release-graph.js
@@ -133,6 +133,7 @@ async function secondPass({
   shouldBumpInRangeDependencies,
   shouldInheritGreaterReleaseType,
   shouldExcludeDevChanges,
+  shouldValidateDependencyVisibility,
 }) {
   function shouldInit({
     dag,
@@ -198,6 +199,15 @@ async function secondPass({
       for (let group of dag.node.dependents) {
         if (group.isCycle) {
           continue;
+        }
+
+        if (
+          shouldValidateDependencyVisibility &&
+          !dag.node.isPackage &&
+          group.node.isPackage &&
+          group.dependencyType === 'dependencies'
+        ) {
+          throw new Error(`Public package "${group.node.packageName}" has a dependency on the private package "${dag.node.packageName}".`);
         }
 
         await crawlDag({
@@ -350,6 +360,7 @@ async function buildReleaseGraph({
   shouldBumpInRangeDependencies,
   shouldInheritGreaterReleaseType,
   shouldExcludeDevChanges,
+  shouldValidateDependencyVisibility,
 }) {
   let logSync = createSyncLogger(_debug);
   let logAsync = createAsyncLogger(_debug);
@@ -369,6 +380,7 @@ async function buildReleaseGraph({
     shouldBumpInRangeDependencies,
     shouldInheritGreaterReleaseType,
     shouldExcludeDevChanges,
+    shouldValidateDependencyVisibility,
   });
 
   // packages without changes, but need to be analyzed because of options

--- a/src/get-changelog.js
+++ b/src/get-changelog.js
@@ -20,6 +20,7 @@ async function getChangelog({
   shouldBumpInRangeDependencies = builder['bump-in-range-dependencies'].default,
   shouldInheritGreaterReleaseType = builder['inherit-greater-release-type'].default,
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
+  shouldValidateDependencyVisibility = builder['validate-dependency-visibility'].default,
   releaseCount = 1,
   fromCommit,
   cached,
@@ -48,6 +49,7 @@ async function getChangelog({
     shouldBumpInRangeDependencies,
     shouldInheritGreaterReleaseType,
     shouldExcludeDevChanges,
+    shouldValidateDependencyVisibility,
   });
 
   let releaseTree = releaseTrees.find(releaseTree => releaseTree.name === name);

--- a/src/get-new-versions.js
+++ b/src/get-new-versions.js
@@ -15,6 +15,7 @@ async function getNewVersions({
   shouldBumpInRangeDependencies = builder['bump-in-range-dependencies'].default,
   shouldInheritGreaterReleaseType = builder['inherit-greater-release-type'].default,
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
+  shouldValidateDependencyVisibility = builder['validate-dependency-visibility'].default,
   fromCommit,
   sinceBranch,
   cached,
@@ -36,6 +37,7 @@ async function getNewVersions({
     shouldBumpInRangeDependencies,
     shouldInheritGreaterReleaseType,
     shouldExcludeDevChanges,
+    shouldValidateDependencyVisibility,
   });
 
   let newVersions = {};

--- a/src/release.js
+++ b/src/release.js
@@ -30,6 +30,7 @@ async function release({
   shouldBumpInRangeDependencies = builder['bump-in-range-dependencies'].default,
   shouldInheritGreaterReleaseType = builder['inherit-greater-release-type'].default,
   shouldExcludeDevChanges = builder['exclude-dev-changes'].default,
+  shouldValidateDependencyVisibility = builder['validate-dependency-visibility'].default,
   shouldCleanUpAfterFailedPush = builder['clean-up-after-failed-push'].default,
   scripts = builder['scripts'].default,
   packageFiles = builder['package-files'].default,
@@ -77,6 +78,7 @@ async function release({
     shouldBumpInRangeDependencies,
     shouldInheritGreaterReleaseType,
     shouldExcludeDevChanges,
+    shouldValidateDependencyVisibility,
   });
 
   for (let releaseTree of releaseTrees) {


### PR DESCRIPTION
This prevents publishing a package that depends on a private package.