### PR TITLE
feat: use existing range if available

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -18,8 +18,14 @@ function trackNewVersion({
       // https://github.com/npm/node-semver/commit/bcab95a966413b978dc1e7bdbcb8f495b63303cd
       range.set[0][0].operator
     ) {
+      let hint = range.raw[0];
+
+      if (hint !== '^' && hint !== '~') {
+        hint = '~';
+      }
+
       // This behaviour can probably be removed in the next major.
-      newRange = `~${newVersion}`;
+      newRange = `${hint}${newVersion}`;
     } else if (
       // NOTE: wildcard range is empty string
       // SEE: https://github.com/npm/node-semver/blob/bcab95a966413b978dc1e7bdbcb8f495b63303cd/test/ranges/to-comparators.js#L10-L12

--- a/test/version-test.js
+++ b/test/version-test.js
@@ -111,14 +111,36 @@ describe(function() {
       expect(newRange).to.equal('');
     });
 
-    it('uses ~ on major version zero with ^', function() {
-      let oldRange = '^0.0.0';
-      let newRange = oldRange;
-      let newVersion = '0.0.1';
+    describe('0.0.0', function() {
+      it('preserves ~', function() {
+        let oldRange = '~0.0.0';
+        let newRange = oldRange;
+        let newVersion = '0.0.1';
 
-      newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+        newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
 
-      expect(newRange).to.equal('~0.0.1');
+        expect(newRange).to.equal('~0.0.1');
+      });
+
+      it('preserves ^', function() {
+        let oldRange = '^0.0.0';
+        let newRange = oldRange;
+        let newVersion = '0.0.1';
+
+        newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+
+        expect(newRange).to.equal('^0.0.1');
+      });
+
+      it('defaults to ~ when unexpected range', function() {
+        let oldRange = '<0.0.1-0';
+        let newRange = oldRange;
+        let newVersion = '0.0.1';
+
+        newRange = trackNewVersion({ name, oldRange, newRange, newVersion });
+
+        expect(newRange).to.equal('~0.0.1');
+      });
     });
 
     it('warns with old range', function() {


### PR DESCRIPTION
Initial versioning can ruin your version hint. For example, from ^0.0.0 to ~1.0.0. This fixes it to be from ^0.0.0 to ^1.0.0.