### PR TITLE
feat: support updating pnpm lockfile

### DIFF
--- a/src/fs.js
+++ b/src/fs.js
@@ -63,10 +63,28 @@ async function ensureWriteFile(path, data) {
   await fs.writeFile(path, data);
 }
 
+/**
+ * @param {string} path
+ */
+async function exists(path) {
+  try {
+    await fs.access(path, fs.constants.F_OK);
+
+    return true;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+
+    return false;
+  }
+}
+
 module.exports = {
   replaceFile,
   replaceJsonFile,
   safeReadFile,
   ensureDir,
   ensureWriteFile,
+  exists,
 };


### PR DESCRIPTION
Unlike other package managers, pnpm stores the package.json version in the lockfile as well. We need to update that during release as well.