### PR TITLE
feat: add `changeTrackingFiles` option to monorepo-next.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Each package can have a `monorepo-next.config.js` with the following options:
 module.exports = {
   // Set this to false to opt-out of change detection and versioning.
   shouldBumpVersion: true,
+
+  // If your package has a build step, your package.json/files array
+  // will be a git-ignored dir, so we can't use that. Use this to
+  // allow us to still find changes to your package. This appends
+  // to your existing NPM tracked files.
+  changeTrackingFiles: ['src'],
 }
 ```
 

--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -212,6 +212,7 @@ async function buildChangeGraph({
       workspacesCwd: workspaceMeta.cwd,
       shouldExcludeDevChanges,
       fromCommit: _fromCommit,
+      nextConfig,
     });
 
     if (shouldOnlyIncludeReleasable && !changedReleasableFiles.length) {

--- a/test/releasable-test.js
+++ b/test/releasable-test.js
@@ -122,6 +122,37 @@ describe(function() {
       ]);
     });
 
+    it('works with changeTrackingFiles', async function() {
+      fixturify.writeSync(this.tmpPath, {
+        'package-a': {
+          'package.json': stringifyJson({
+            'name': 'package-a',
+            'version': '1.0.0',
+            'files': ['dist'],
+          }),
+          dist: '',
+          src: '',
+        },
+      });
+
+      let changedReleasableFiles = await getChangedReleasableFiles({
+        changedFiles: [
+          'package-a/dist',
+          'package-a/src',
+        ],
+        packageCwd: path.join(this.tmpPath, 'package-a'),
+        workspacesCwd: this.tmpPath,
+        nextConfig: {
+          changeTrackingFiles: ['src'],
+        },
+      });
+
+      expect(changedReleasableFiles).to.deep.equal([
+        'package-a/dist',
+        'package-a/src',
+      ]);
+    });
+
     it('injected and changed files are included', async function() {
       fixturify.writeSync(this.tmpPath, {
         'package-a': {


### PR DESCRIPTION
Packages that have a build step don't get tracked during the release process. Because their `files` array has something like `dist`, it doesn't track any files in git, and it looks like it doesn't have any releasable changes. This option appends your existing NPM settings, so you don't have to duplicate a long files list.