### PR TITLE
fix: follow private dependents all the way down

### DIFF
--- a/src/build-dag.js
+++ b/src/build-dag.js
@@ -67,14 +67,17 @@ function thirdPass({
 
       group.node.dependents.push(newGroup);
 
-      if (group.node.isPackage) {
-        thirdPass({
-          workspaceMeta,
-          group: newGroup,
-          branch: newBranch,
-          visitedNodes,
-        });
-      }
+      // We don't want to check if it's private here because
+      // you could have a chain of private packages, and you
+      // want to bump them all the way down.
+      // if (group.node.isPackage) {
+      thirdPass({
+        workspaceMeta,
+        group: newGroup,
+        branch: newBranch,
+        visitedNodes,
+      });
+      // }
     }
   }
 }


### PR DESCRIPTION
The bug stopped at the first level. It assumed private packages are only devDependencies, but if your monorepo is all private packages, including dependencies, you will break the tree if only going one layer deep.