### PR TITLE
fix: when renaming or moving a file, also add the new file to the cha…

### DIFF
--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -42,20 +42,24 @@ async function getPackageChangedFiles({
   committedChanges = getLinesFromOutput(committedChanges).reduce((committedChanges, line) => {
     let isDeleted = line[0] === 'D';
     let isRename = line[0] === 'R';
-    let shouldExclude = shouldExcludeDeleted && isDeleted;
+    let shouldExclude = shouldExcludeDeleted && (isDeleted || isRename);
+    line = line.split('\t');
 
     if (!shouldExclude) {
-      line = line.split('\t');
       // renames are denoted by `R[01 - 100]  <old filename>  <new filename>` so we need to grab <new filename> as well`
       if (isRename) {
         // add both old and new filename
         committedChanges.add(line[1]);
         committedChanges.add(line[2]);
-
-
       } else {
         // rely on tab char between change signifier char and changed filepath
         committedChanges.add(line[1]);
+      }
+    } else {
+      if (isRename) {
+        // with renames, we still exclude the old file name
+        // but the renamed file should be considered "new"
+        committedChanges.add(line[2]);
       }
     }
 

--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -46,21 +46,11 @@ async function getPackageChangedFiles({
     line = line.split('\t');
 
     if (!shouldExclude) {
+      committedChanges.add(line[1]);
+    }
+    if (isRename) {
       // renames are denoted by `R[01 - 100]  <old filename>  <new filename>` so we need to grab <new filename> as well`
-      if (isRename) {
-        // add both old and new filename
-        committedChanges.add(line[1]);
-        committedChanges.add(line[2]);
-      } else {
-        // rely on tab char between change signifier char and changed filepath
-        committedChanges.add(line[1]);
-      }
-    } else {
-      if (isRename) {
-        // with renames, we still exclude the old file name
-        // but the renamed file should be considered "new"
-        committedChanges.add(line[2]);
-      }
+      committedChanges.add(line[2]);
     }
 
     return committedChanges;

--- a/src/build-change-graph.js
+++ b/src/build-change-graph.js
@@ -41,12 +41,22 @@ async function getPackageChangedFiles({
 
   committedChanges = getLinesFromOutput(committedChanges).reduce((committedChanges, line) => {
     let isDeleted = line[0] === 'D';
+    let isRename = line[0] === 'R';
     let shouldExclude = shouldExcludeDeleted && isDeleted;
 
     if (!shouldExclude) {
-      line = line.substr(2);
+      line = line.split('\t');
+      // renames are denoted by `R[01 - 100]  <old filename>  <new filename>` so we need to grab <new filename> as well`
+      if (isRename) {
+        // add both old and new filename
+        committedChanges.add(line[1]);
+        committedChanges.add(line[2]);
 
-      committedChanges.add(line);
+
+      } else {
+        // rely on tab char between change signifier char and changed filepath
+        committedChanges.add(line[1]);
+      }
     }
 
     return committedChanges;

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -438,7 +438,6 @@ describe(buildChangeGraph, function() {
     });
 
     it('with shouldExcludeDeleted = false', async function() {
-
       let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
 
       let packagesWithChanges = await buildChangeGraph({ workspaceMeta, shouldExcludeDeleted: false });
@@ -463,7 +462,6 @@ describe(buildChangeGraph, function() {
     });
 
     it('with shouldExcludeDeleted = true', async function() {
-
       let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
 
       let packagesWithChanges = await buildChangeGraph({ workspaceMeta, shouldExcludeDeleted: true });

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -402,6 +402,118 @@ describe(buildChangeGraph, function() {
     ]));
   });
 
+  it('handles a committed directory rename (trailing / shows up in git status)', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-a',
+            'version': '1.0.0',
+          }),
+          'dir1': {
+            'test.txt': 'testing',
+          },
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+
+    await fs.rename(
+      path.join(tmpPath, 'packages/package-a/dir1'),
+      path.join(tmpPath, 'packages/package-a/dir2'),
+    );
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
+
+    console.log(packagesWithChanges);
+
+    expect(packagesWithChanges).to.match(this.match([
+      {
+        changedFiles: [
+          'packages/package-a/dir1/test.txt',
+          'packages/package-a/dir2/test.txt',
+        ],
+        changedReleasableFiles: [
+          'packages/package-a/dir1/test.txt',
+          'packages/package-a/dir2/test.txt',
+        ],
+        dag: this.match({
+          node: {
+            packageName: '@scope/package-a',
+          },
+        }),
+      },
+    ]));
+  });
+
+  it('handles changed filenames with space when changes are commited', async function() {
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'package.json': stringifyJson({
+            'name': '@scope/package-a',
+            'version': '1.0.0',
+          }),
+        },
+      },
+      'package.json': stringifyJson({
+        'private': true,
+        'workspaces': [
+          'packages/*',
+        ],
+      }),
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+
+    fixturify.writeSync(tmpPath, {
+      'packages': {
+        'package-a': {
+          'sample index.js': 'console.log()',
+        },
+      },
+    });
+
+    await execa('git', ['add', '.'], { cwd: tmpPath });
+    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+
+    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
+
+    expect(packagesWithChanges).to.match(this.match([
+      {
+        changedFiles: [
+          'packages/package-a/sample index.js',
+        ],
+        changedReleasableFiles: [
+          'packages/package-a/sample index.js',
+        ],
+        dag: this.match({
+          node: {
+            packageName: '@scope/package-a',
+          },
+        }),
+      },
+    ]));
+  });
+
   it('tracks workspace with a version', async function() {
     fixturify.writeSync(tmpPath, {
       'package.json': stringifyJson({
@@ -930,7 +1042,7 @@ describe(buildChangeGraph, function() {
     ]));
   });
 
-  it('can calulate difference since branch point', async function() {
+  it('can calculate difference since branch point', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {

--- a/test/build-change-graph-test.js
+++ b/test/build-change-graph-test.js
@@ -351,7 +351,7 @@ describe(buildChangeGraph, function() {
     ]));
   });
 
-  it('handles changed filenames with space when changes are not commited', async function() {
+  it('handles changed filenames with space when changes are not committed', async function() {
     fixturify.writeSync(tmpPath, {
       'packages': {
         'package-a': {
@@ -402,116 +402,88 @@ describe(buildChangeGraph, function() {
     ]));
   });
 
-  it('handles a committed directory rename (trailing / shows up in git status)', async function() {
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          'package.json': stringifyJson({
-            'name': '@scope/package-a',
-            'version': '1.0.0',
-          }),
-          'dir1': {
-            'test.txt': 'testing',
+  describe('handles a committed directory rename (trailing / shows up in git status)', function() {
+    beforeEach(async function() {
+      fixturify.writeSync(tmpPath, {
+        'packages': {
+          'package-a': {
+            'package.json': stringifyJson({
+              'name': '@scope/package-a',
+              'version': '1.0.0',
+            }),
+            'dir1': {
+              'test.txt': 'testing',
+            },
           },
         },
-      },
-      'package.json': stringifyJson({
-        'private': true,
-        'workspaces': [
-          'packages/*',
-        ],
-      }),
+        'package.json': stringifyJson({
+          'private': true,
+          'workspaces': [
+            'packages/*',
+          ],
+        }),
+      });
+
+      await execa('git', ['add', '.'], { cwd: tmpPath });
+      await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+      await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+
+      await fs.rename(
+        path.join(tmpPath, 'packages/package-a/dir1'),
+        path.join(tmpPath, 'packages/package-a/dir2'),
+      );
+
+      await execa('git', ['add', '.'], { cwd: tmpPath });
+      await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
     });
 
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+    it('with shouldExcludeDeleted = false', async function() {
 
-    await fs.rename(
-      path.join(tmpPath, 'packages/package-a/dir1'),
-      path.join(tmpPath, 'packages/package-a/dir2'),
-    );
+      let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
 
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
+      let packagesWithChanges = await buildChangeGraph({ workspaceMeta, shouldExcludeDeleted: false });
 
-    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
-
-    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
-
-    console.log(packagesWithChanges);
-
-    expect(packagesWithChanges).to.match(this.match([
-      {
-        changedFiles: [
-          'packages/package-a/dir1/test.txt',
-          'packages/package-a/dir2/test.txt',
-        ],
-        changedReleasableFiles: [
-          'packages/package-a/dir1/test.txt',
-          'packages/package-a/dir2/test.txt',
-        ],
-        dag: this.match({
-          node: {
-            packageName: '@scope/package-a',
-          },
-        }),
-      },
-    ]));
-  });
-
-  it('handles changed filenames with space when changes are commited', async function() {
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          'package.json': stringifyJson({
-            'name': '@scope/package-a',
-            'version': '1.0.0',
+      expect(packagesWithChanges).to.match(this.match([
+        {
+          changedFiles: [
+            'packages/package-a/dir1/test.txt',
+            'packages/package-a/dir2/test.txt',
+          ],
+          changedReleasableFiles: [
+            'packages/package-a/dir1/test.txt',
+            'packages/package-a/dir2/test.txt',
+          ],
+          dag: this.match({
+            node: {
+              packageName: '@scope/package-a',
+            },
           }),
         },
-      },
-      'package.json': stringifyJson({
-        'private': true,
-        'workspaces': [
-          'packages/*',
-        ],
-      }),
+      ]));
     });
 
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-    await execa('git', ['tag', '@scope/package-a@1.0.0'], { cwd: tmpPath });
+    it('with shouldExcludeDeleted = true', async function() {
 
-    fixturify.writeSync(tmpPath, {
-      'packages': {
-        'package-a': {
-          'sample index.js': 'console.log()',
+      let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
+
+      let packagesWithChanges = await buildChangeGraph({ workspaceMeta, shouldExcludeDeleted: true });
+
+      expect(packagesWithChanges).to.match(this.match([
+        {
+          changedFiles: [
+            'packages/package-a/dir2/test.txt',
+          ],
+          changedReleasableFiles: [
+            'packages/package-a/dir2/test.txt',
+          ],
+          dag: this.match({
+            node: {
+              packageName: '@scope/package-a',
+            },
+          }),
         },
-      },
+      ]));
     });
-
-    await execa('git', ['add', '.'], { cwd: tmpPath });
-    await execa('git', ['commit', '-m', 'test'], { cwd: tmpPath });
-
-    let workspaceMeta = await buildDepGraph({ workspaceCwd: tmpPath });
-
-    let packagesWithChanges = await buildChangeGraph({ workspaceMeta });
-
-    expect(packagesWithChanges).to.match(this.match([
-      {
-        changedFiles: [
-          'packages/package-a/sample index.js',
-        ],
-        changedReleasableFiles: [
-          'packages/package-a/sample index.js',
-        ],
-        dag: this.match({
-          node: {
-            packageName: '@scope/package-a',
-          },
-        }),
-      },
-    ]));
   });
 
   it('tracks workspace with a version', async function() {


### PR DESCRIPTION
When committing renames or moved files, `git diff` outputs something like:

`R100	old-file-path/test-name.js	new-file-path/test-name.js`

Currently, `getPackageChangedFiles` will parse the changes incorrectly, outputting a changedFile array of `100 old-file-path/test-name.js	new-file-path/test-name.js` as it only expects `git diff` markers of a single char like `M` or `A` as well as only one file path, not two

This will bubble up and have `changedFiles` to output an array containing a mangled string of `'00\told-file-path/test-name.js\tnew-file-path/test-name.js',` that includes both the old and new file path and the rename % digits and tab chars (\t) in one string.

With this change, we can treat renames correctly, and grab both old and new file paths,. so it outputs both paths separately:
`old-file-path/test-name.js, new-file-path/test-name.js`

`dirtyFiles` aka uncommitted changes were not affected by the bug as they are parsed correctly with `git status --porcelain`